### PR TITLE
Adds the ability to access nested attributes from the queried records.

### DIFF
--- a/lib/ar-find-in-batches-with-order.rb
+++ b/lib/ar-find-in-batches-with-order.rb
@@ -57,7 +57,7 @@ module ActiveRecord
     end
 
     def get_property_val(record, parent_key, property_key)
-      parent_key ? record.as_json(include: parent_key).dig(parent_key, property_key) : record.send(property_key)
+      parent_key ? record.send(parent_key).send(property_key) : record.send(property_key)
     end
   end
 


### PR DESCRIPTION
Handles nested values for Rails < 6.0.3 versions that don't allow you to add attributes from joined tables when using includes.

https://github.com/rails/rails/issues/34889